### PR TITLE
Replaced return call with continue call

### DIFF
--- a/src/main/java/com/mesabrook/ib/util/handlers/ServerTickHandler.java
+++ b/src/main/java/com/mesabrook/ib/util/handlers/ServerTickHandler.java
@@ -153,7 +153,7 @@ public class ServerTickHandler {
 				if (employeeCap.getLocationID() == 0)
 				{
 					employeeCap.serverToClientSync();
-					return;
+					continue;
 				}
 				
 				enqueueStoreModeUpdateNow(player);


### PR DESCRIPTION
Fixes https://github.com/Mesabrook-Development-Team/Immersibrook/issues/89
Replaces `return;` with `continue;` on line 156 of `ServerTickHandler`